### PR TITLE
add toothless,config, and verbose options

### DIFF
--- a/tip_bot.py
+++ b/tip_bot.py
@@ -147,6 +147,9 @@ class TipBot:
 
         elif "/tip" == cmd or "/send" == cmd:
             if args is not None and len(args) >= 1:
+                if options.verbose:
+                    print("self.message.reply_to_message:")
+                    print(self.message.reply_to_message)
                 if self.message.reply_to_message is not None:
                     if options.verbose:
                         print("running tip_in_the_chat() with args:")

--- a/tip_bot.py
+++ b/tip_bot.py
@@ -12,6 +12,7 @@ import argparse
 parser = argparse.ArgumentParser()
 parser.add_argument("-c", "--config", type=str, required=True, help="Config file")
 parser.add_argument("-t", "--toothless", help="Does not send transactions", action="store_true")
+parser.add_argument("-v", "--verbose", help="A more verbose output", action="store_true")
 args = parser.parse_args()
 
 with open(args.config) as conf_file:
@@ -88,6 +89,9 @@ class TipBot:
         try:
             return str(self.message.from_user.username)
         except:
+            if args.verbose:
+                print("Could not find username for:")
+                print(self.message)
             return None
 
 

--- a/tip_bot.py
+++ b/tip_bot.py
@@ -7,7 +7,14 @@ from pymongo import MongoClient
 from telegram import Bot
 from web3 import Web3, HTTPProvider
 
-with open('services.json') as conf_file:
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-c", "--config", type=str, required=True, help="Config file")
+parser.add_argument("-t", "--toothless", help="Does not send transactions", action="store_true")
+args = parser.parse_args()
+
+with open(args.config) as conf_file:
     conf = json.load(conf_file)
     connectionString = conf['mongo']['connectionString']
     http_provider = conf['web3']['provider']
@@ -277,8 +284,11 @@ class TipBot:
                 _private_key = self.col_users.find_one({"_id": self.user_id})['TomoPrivateKey']
                 signed_txn = self.w3.eth.account.signTransaction(txn,
                                                                  private_key=_private_key)
-                tx = self.w3.eth.sendRawTransaction(signed_txn.rawTransaction)
-                tx = self.w3.toHex(tx)
+                if args.toothless:
+                    tx = signex_txn.hash.hex()
+                else:
+                    tx = self.w3.eth.sendRawTransaction(signed_txn.rawTransaction)
+                    tx = self.w3.toHex(tx)
 
                 self.bot.send_message(self.user_id,
                                       dictionary['withdrawal_result'] % (amount, address, tx),
@@ -322,8 +332,11 @@ class TipBot:
                 _private_key = self.col_users.find_one({"_id": self.user_id})['TomoPrivateKey']
                 signed_txn = self.w3.eth.account.signTransaction(txn,
                                                                  private_key=_private_key)
-                tx = self.w3.eth.sendRawTransaction(signed_txn.rawTransaction)
-                tx = self.w3.toHex(tx)
+                if args.toothless:
+                    tx = signed_txn.hash.hex()
+                else:
+                    tx = self.w3.eth.sendRawTransaction(signed_txn.rawTransaction)
+                    tx = self.w3.toHex(tx)
 
                 self.bot.send_message(self.user_id,
                                       dictionary['donate_result'] % (balance, tx),
@@ -415,8 +428,11 @@ class TipBot:
                     'TomoPrivateKey']
                 signed_txn = self.w3.eth.account.signTransaction(txn,
                                                                  private_key=_private_key)
-                tx = self.w3.eth.sendRawTransaction(signed_txn.rawTransaction)
-                tx = self.w3.toHex(tx)
+                if args.toothless:
+                    tx = signed_txn.hash.hex()
+                else:
+                    tx = self.w3.eth.sendRawTransaction(signed_txn.rawTransaction)
+                    tx = self.w3.toHex(tx)
 
                 self.bot.send_message(user_id,
                                       dictionary['tip_recieved'] % (amount, coin, tx),

--- a/tip_bot.py
+++ b/tip_bot.py
@@ -148,8 +148,8 @@ class TipBot:
         elif "/tip" == cmd or "/send" == cmd:
             if args is not None and len(args) >= 1:
                 if options.verbose:
-                    print("self.message.reply_to_message:")
-                    print(self.message.reply_to_message)
+                    print("self.message:")
+                    print(self.message)
                 if self.message.reply_to_message is not None:
                     if options.verbose:
                         print("running tip_in_the_chat() with args:")

--- a/tip_bot.py
+++ b/tip_bot.py
@@ -13,9 +13,9 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-c", "--config", type=str, required=True, help="Config file")
 parser.add_argument("-t", "--toothless", help="Does not send transactions", action="store_true")
 parser.add_argument("-v", "--verbose", help="A more verbose output", action="store_true")
-args = parser.parse_args()
+options = parser.parse_args()
 
-with open(args.config) as conf_file:
+with open(options.config) as conf_file:
     conf = json.load(conf_file)
     connectionString = conf['mongo']['connectionString']
     http_provider = conf['web3']['provider']
@@ -89,7 +89,7 @@ class TipBot:
         try:
             return str(self.message.from_user.username)
         except:
-            if args.verbose:
+            if options.verbose:
                 print("Could not find username for:")
                 print(self.message)
             return None
@@ -148,12 +148,12 @@ class TipBot:
         elif "/tip" == cmd or "/send" == cmd:
             if args is not None and len(args) >= 1:
                 if self.message.reply_to_message is not None:
-                    if args.verbose:
+                    if options.verbose:
                         print("running tip_in_the_chat() with args:")
                         print(*args)
                     self.tip_in_the_chat(*args)
                 else:
-                    if args.verbose:
+                    if options.verbose:
                         print("running tip_user() with args:")
                         print(*args)
                     self.tip_user(*args)
@@ -296,7 +296,7 @@ class TipBot:
                 _private_key = self.col_users.find_one({"_id": self.user_id})['TomoPrivateKey']
                 signed_txn = self.w3.eth.account.signTransaction(txn,
                                                                  private_key=_private_key)
-                if args.toothless:
+                if options.toothless:
                     tx = signex_txn.hash.hex()
                 else:
                     tx = self.w3.eth.sendRawTransaction(signed_txn.rawTransaction)
@@ -344,7 +344,7 @@ class TipBot:
                 _private_key = self.col_users.find_one({"_id": self.user_id})['TomoPrivateKey']
                 signed_txn = self.w3.eth.account.signTransaction(txn,
                                                                  private_key=_private_key)
-                if args.toothless:
+                if options.toothless:
                     tx = signed_txn.hash.hex()
                 else:
                     tx = self.w3.eth.sendRawTransaction(signed_txn.rawTransaction)
@@ -440,7 +440,7 @@ class TipBot:
                     'TomoPrivateKey']
                 signed_txn = self.w3.eth.account.signTransaction(txn,
                                                                  private_key=_private_key)
-                if args.toothless:
+                if options.toothless:
                     tx = signed_txn.hash.hex()
                 else:
                     tx = self.w3.eth.sendRawTransaction(signed_txn.rawTransaction)

--- a/tip_bot.py
+++ b/tip_bot.py
@@ -27,6 +27,8 @@ with open(args.config) as conf_file:
 class TipBot:
     def __init__(self, w3):
 
+        print("Running toothless. Transactions will not be sent")
+
         self.w3 = w3
         print("Web3 Connected: %s " % self.w3.isConnected())
 

--- a/tip_bot.py
+++ b/tip_bot.py
@@ -148,8 +148,14 @@ class TipBot:
         elif "/tip" == cmd or "/send" == cmd:
             if args is not None and len(args) >= 1:
                 if self.message.reply_to_message is not None:
+                    if args.verbose:
+                        print("running tip_in_the_chat() with args:")
+                        print(*args)
                     self.tip_in_the_chat(*args)
                 else:
+                    if args.verbose:
+                        print("running tip_user() with args:")
+                        print(*args)
                     self.tip_user(*args)
             else:
                 self.bot.send_message(self.user_id,


### PR DESCRIPTION
config file now a required argument, but filename isn't hardcoded.
`python tip_bot --config /path/to/config.json`

bot can be ran in toothless mode. Transactions are not broadcast with toothless
`python tip_bot --toothless --config /path/to/config.json`